### PR TITLE
Rethrow unhandled request error and always log for rate limit

### DIFF
--- a/src/Endpoints/BaseEndpoint.php
+++ b/src/Endpoints/BaseEndpoint.php
@@ -118,9 +118,10 @@ abstract class BaseEndpoint
 				}
 				
 				//file_put_contents("/tmp/pwsync.log","Sync exception: " . $error, FILE_APPEND);
-			}
-			
-            RateLimit::do()->pushRequest();
+                throw $e;
+            } finally {
+                RateLimit::do()->pushRequest();
+            }
             return $this->processResponse($response);
         }
     }


### PR DESCRIPTION
When trying to update a resource that doesn't exist, i'd get
```
Undefined variable: response
in /var/www/vendor/smith-carson/prosperworks-sdk/src/Endpoints/BaseEndpoint.php:124
```

This PR handles this by rethrowing the orignal exception (in this case `Client error: `PUT https://api.prosperworks.com/...` resulted in a `404 Not Found` `)

It also makes sure the rate limiter is always called